### PR TITLE
Attempt to reduce the number of digits shown to only the significant needed.

### DIFF
--- a/implutt.cpp
+++ b/implutt.cpp
@@ -1919,13 +1919,21 @@ namespace ImPlutt {
       }
     }
     if (m_window->ContainsLocal(m_rect_graph, m_window->m_pointer)) {
+      char buf[100];
       // Draw pointer coordinates.
       auto px = PointFromPosX(curr.x);
       auto py = PointFromPosY(curr.y);
-      std::ostringstream oss;
-      oss << px << ',' << py;
-      auto str = oss.str();
-      m_window->PlotText(this, str.c_str(), Point(px, py), TEXT_ABOVE, true,
+      // Only use as many digits as needed to represent the difference
+      // on screen with the actual value being printed.
+      int x_digits = 2 -
+	  (int) log10((m_max.x - m_min.x) / m_rect_graph.w) +
+	  (int) log10(fabs(px));
+      int y_digits = 2 -
+	  (int) log10((m_max.y - m_min.y) / m_rect_graph.h) +
+	  (int) log10(fabs(py));
+      snprintf(buf, sizeof buf, "%.*g, %.*g",
+	       x_digits, px, y_digits, py);
+      m_window->PlotText(this, buf, Point(px, py), TEXT_ABOVE, true,
           true);
     }
     // Transparent projection band.


### PR DESCRIPTION
Such that the user need not parse more info than needed.

A bit irritating is that %g drops 0s at the end, making the number of digits still jump when 0s are encountered.