### PR TITLE
Freebsd build fixes.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,6 +113,12 @@ ifeq (Darwin,$(shell uname -s))
 LDFLAGS:=-framework CoreServices
 endif
 
+# FreeBSD inotify for file watching.
+
+ifeq (FreeBSD,$(shell uname -s))
+LIBS+=-linotify
+endif
+
 # Bison flags.
 
 # --version prints info to stdout if the -W flags are accepted, else stderr.

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ QUIET=@
 # ccache?
 
 ifeq ($(shell (ccache --version 2>/dev/null && echo YesBox) | grep YesBox),YesBox)
-CXX:=ccache g++
+CCACHE:=ccache
 $(info ccache: yes)
 else
 $(info ccache: no)
@@ -175,16 +175,16 @@ $(TEST): $(TEST_OBJ) $(filter-out %main.o,$(OBJ)) $(ROOT_DICT_PCM)
 $(BUILD_DIR)/%.o: %.cpp Makefile
 	@echo O $@
 	$(QUIET)$(MKDIR)
-	$(QUIET)$(CXX) -c -o $@ $< $(CPPFLAGS) $(CXXFLAGS)
+	$(QUIET)$(CCACHE) $(CXX) -c -o $@ $< $(CPPFLAGS) $(CXXFLAGS)
 
 $(BUILD_DIR)/%.o: %.c Makefile
 	@echo O $@
 	$(QUIET)$(MKDIR)
-	$(QUIET)$(CXX) -c -o $@ $< $(CPPFLAGS) $(CXXFLAGS)
+	$(QUIET)$(CCACHE) $(CXX) -c -o $@ $< $(CPPFLAGS) $(CXXFLAGS)
 
 $(BUILD_DIR)/%.yy.o: $(BUILD_DIR)/%.yy.c
 	@echo LEXO $@
-	$(QUIET)$(CXX) -c -o $@ $< $(CPPFLAGS) $(CXXFLAGS_UNSAFE)
+	$(QUIET)$(CCACHE) $(CXX) -c -o $@ $< $(CPPFLAGS) $(CXXFLAGS_UNSAFE)
 $(BUILD_DIR)/%.yy.c: %.l
 	@echo LEXC $@
 	$(QUIET)$(MKDIR)
@@ -192,7 +192,7 @@ $(BUILD_DIR)/%.yy.c: %.l
 
 $(BUILD_DIR)/%.tab.o: $(BUILD_DIR)/%.tab.c
 	@echo TABO $@
-	$(QUIET)$(CXX) -c -o $@ $< $(CPPFLAGS) $(CXXFLAGS_UNSAFE)
+	$(QUIET)$(CCACHE) $(CXX) -c -o $@ $< $(CPPFLAGS) $(CXXFLAGS_UNSAFE)
 $(BUILD_DIR)/src/config_parser.tab.c: src/config_parser.y Makefile
 	@echo TABC $@
 	$(QUIET)$(MKDIR)
@@ -218,17 +218,17 @@ $(BUILD_DIR)/src/root.o \
     $(BUILD_DIR)/src/root_output.o:
 	@echo ROOTO $@
 	$(QUIET)$(MKDIR)
-	$(QUIET)$(CXX) -c -o $@ $< $(CPPFLAGS) $(CXXFLAGS) $(ROOT_CFLAGS)
+	$(QUIET)$(CCACHE) $(CXX) -c -o $@ $< $(CPPFLAGS) $(CXXFLAGS) $(ROOT_CFLAGS)
 
 $(BUILD_DIR)/test/test_root.o: test/test_root.cpp Makefile
 	@echo ROOTO $@
 	$(QUIET)$(MKDIR)
-	$(QUIET)$(CXX) -c -o $@ $< $(CPPFLAGS) $(CXXFLAGS) $(ROOT_CFLAGS)
+	$(QUIET)$(CCACHE) $(CXX) -c -o $@ $< $(CPPFLAGS) $(CXXFLAGS) $(ROOT_CFLAGS)
 
 $(BUILD_DIR)/test/test_root_dict.o: $(BUILD_DIR)/test/test_root_dict.cpp
 	@echo ROOTO $@
 	$(QUIET)$(MKDIR)
-	$(QUIET)$(CXX) -c -o $@ $< $(CPPFLAGS) $(ROOT_CFLAGS)
+	$(QUIET)$(CCACHE) $(CXX) -c -o $@ $< $(CPPFLAGS) $(ROOT_CFLAGS)
 
 $(BUILD_DIR)/test/test_root_dict.cpp: test/test_root.hpp test/test_root_linkdef.hpp
 	@echo CLING $@

--- a/src/filewatcher.cpp
+++ b/src/filewatcher.cpp
@@ -25,9 +25,12 @@
 #include <vector>
 #include <filewatcher.hpp>
 
-#ifdef __linux__
+#if defined( __linux__) || defined(__FreeBSD__)
 
+#ifdef __linux__
 #       include <linux/limits.h>
+#endif
+#       include <limits.h>
 #       include <sys/inotify.h>
 #       include <sys/poll.h>
 #       include <cstring>

--- a/src/filewatcher.cpp
+++ b/src/filewatcher.cpp
@@ -90,7 +90,7 @@ std::string FileWatcherImpl::WaitFile(unsigned a_timeout_ms)
 
     fds[0].fd = m_fd;
     fds[0].events = POLLIN;
-    nfds = poll(fds, LENGTH(fds), a_timeout_ms);
+    nfds = poll(fds, LENGTH(fds), (int) a_timeout_ms);
     if (nfds < 0) {
       std::cerr << "poll: " << strerror(errno) << ".\n";
       throw std::runtime_error(__func__);


### PR DESCRIPTION
Note: I'm having bad results with ccache.
```
LD build_x86_64-unknown-freebsd14.3_19.1.7_debug/tests
/usr/local/bin/ld: ../ucesb/hbook/ext_data_clnt.o: undefined reference to symbol '_ZNSt9bad_allocC1Ev@@CXXRT_1.0'
/usr/local/bin/ld: /lib/libcxxrt.so.1: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
```
possibly only when being used for linking.
Not using it for anything else, so uninstalled it again...