### PR TITLE
Include <cmath> as root does not in newer versions.

### DIFF
--- a/src/root_gui.cpp
+++ b/src/root_gui.cpp
@@ -25,6 +25,7 @@
 #include <iostream>
 #include <list>
 #include <sstream>
+#include <cmath>
 
 #include <TCanvas.h>
 #include <TGraph.h>


### PR DESCRIPTION
As of ROOT version 6.38 ([release notes](https://root.cern/doc/v638/release-notes.html)) some unused includes were erased from some header files. One of them being cmath which is used in root_gui.cc. This commit adds that missing include.