### PR TITLE
Option to use a fixed number of columns in a page.

### DIFF
--- a/README.md
+++ b/README.md
@@ -749,10 +749,11 @@ colormap("name")
 ```
 
 ```
-page("name")
+page("name" [, cols})
 
 	Starts a new named page for plots. If the user did not create one
 	before the first plot, a default named "Default" is made.
+	The number of columns to use can optionally be specified.
 ```
 
 ```

--- a/include/gui.hpp
+++ b/include/gui.hpp
@@ -60,7 +60,7 @@ class Gui {
     virtual ~Gui();
 
   protected:
-    virtual void AddPage(std::string const &) = 0;
+    virtual void AddPage(std::string const &, int = 0) = 0;
     virtual uint32_t AddPlot(std::string const &, Plot *) = 0;
 
     virtual bool DoClear(uint32_t) = 0;
@@ -83,7 +83,7 @@ class GuiCollection {
   public:
     void AddGui(Gui *);
 
-    void AddPage(std::string const &);
+    void AddPage(std::string const &, int = 0);
     uint32_t AddPlot(std::string const &, Gui::Plot *);
 
     bool DoClear(uint32_t);

--- a/include/root_gui.hpp
+++ b/include/root_gui.hpp
@@ -40,7 +40,7 @@ class RootGui: public Gui {
     RootGui(uint16_t);
     ~RootGui();
 
-    void AddPage(std::string const &);
+    void AddPage(std::string const &,int = 0);
     uint32_t AddPlot(std::string const &, Plot *);
 
     bool DoClear(uint32_t);
@@ -86,6 +86,7 @@ class RootGui: public Gui {
     struct Page {
       Page();
       std::string name;
+      int cols;
       TCanvas *canvas;
       std::vector<PlotWrap *> plot_wrap_vec;
       std::list<Bind *> m_bind_list;

--- a/include/sdl_gui.hpp
+++ b/include/sdl_gui.hpp
@@ -32,7 +32,7 @@ class SdlGui: public Gui {
     SdlGui(char const *, unsigned, unsigned);
     ~SdlGui();
 
-    void AddPage(std::string const &);
+    void AddPage(std::string const &,int = 0);
     uint32_t AddPlot(std::string const &, Plot *);
 
     bool DoClear(uint32_t);
@@ -66,6 +66,7 @@ class SdlGui: public Gui {
     struct Page {
       Page();
       std::string name;
+      int cols;
       std::vector<PlotWrap *> plot_wrap_vec;
     };
     ImPlutt::Window *m_window;

--- a/src/config_parser.y
+++ b/src/config_parser.y
@@ -380,6 +380,10 @@ page
 		g_gui.AddPage($3);
 		free($3);
 	}
+	| TK_PAGE '(' TK_STRING ',' TK_INTEGER ')' {
+		g_gui.AddPage($3, $5.i64);
+		free($3);
+	}
 
 const
 	: TK_DOUBLE { $$ = $1; }

--- a/src/gui.cpp
+++ b/src/gui.cpp
@@ -77,11 +77,11 @@ void GuiCollection::AddGui(Gui *a_gui)
 #define FOR_GUI \
   for (auto it = m_gui_map.begin(); m_gui_map.end() != it; ++it)
 
-void GuiCollection::AddPage(std::string const &a_name)
+void GuiCollection::AddPage(std::string const &a_name,int a_cols)
 {
   FOR_GUI {
     auto gui = it->first;
-    gui->AddPage(a_name);
+    gui->AddPage(a_name, a_cols);
   }
 }
 

--- a/src/root_gui.cpp
+++ b/src/root_gui.cpp
@@ -147,11 +147,12 @@ RootGui::~RootGui()
   delete m_server;
 }
 
-void RootGui::AddPage(std::string const &a_name)
+void RootGui::AddPage(std::string const &a_name,int a_cols)
 {
   m_page_vec.push_back(new Page);
   auto page = m_page_vec.back();
   page->name = a_name;
+  page->cols = a_cols;
   {
     std::string clean_name = CleanName(page->name);
     std::string bind_name = "plutt_BindClearPage_" + clean_name;
@@ -215,8 +216,14 @@ bool RootGui::Draw(double a_event_rate)
     auto page = *it;
     auto &vec = page->plot_wrap_vec;
     if (!page->canvas) {
-      auto rows = (int)sqrt((double)vec.size());
-      auto cols = ((int)vec.size() + rows - 1) / rows;
+      int rows, cols;
+      if (page->cols) {
+	cols = page->cols;
+	rows = ((int)vec.size() + cols - 1) / cols;
+      } else {
+	rows = (int)sqrt((double)vec.size());
+	cols = ((int)vec.size() + rows - 1) / rows;
+      }
       page->canvas = new TCanvas(page->name.c_str(), page->name.c_str());
       page->canvas->Divide(cols, rows, 0.01f, 0.01f);
       m_server->Register("/", page->canvas);

--- a/src/sdl_gui.cpp
+++ b/src/sdl_gui.cpp
@@ -69,11 +69,12 @@ SdlGui::~SdlGui()
   delete m_window;
 }
 
-void SdlGui::AddPage(std::string const &a_name)
+void SdlGui::AddPage(std::string const &a_name, int a_cols)
 {
   m_page_vec.push_back(new Page);
   auto page = m_page_vec.back();
   page->name = a_name;
+  page->cols = a_cols;
 }
 
 uint32_t SdlGui::AddPlot(std::string const &a_name, Plot *a_plot)
@@ -150,8 +151,14 @@ bool SdlGui::Draw(double a_event_rate)
   size.y = std::max(0, size.y - h);
   {
     auto &vec = m_page_sel->plot_wrap_vec;
-    int rows = (int)sqrt((double)vec.size());
-    int cols = ((int)vec.size() + rows - 1) / rows;
+    int rows, cols;
+    if (m_page_sel->cols) {
+      cols = m_page_sel->cols;
+      rows = ((int)vec.size() + cols - 1) / cols;
+    } else {
+      rows = (int)sqrt((double)vec.size());
+      cols = ((int)vec.size() + rows - 1) / rows;
+    }
     ImPlutt::Pos elem_size(size.x / cols, size.y / rows);
     ImPlutt::Rect elem_rect;
     elem_rect.x = 0;


### PR DESCRIPTION
With this, the plots in this case align better than the default (it would be 4 per row...):

<img width="808" height="628" alt="screenshot_3cols" src="https://github.com/user-attachments/assets/0e08da35-e619-4920-b7f6-e85dc7bf99ca" />
