### PR TITLE
Initial guess for Gauss fit parameters based on #counts, mean and variance.

### DIFF
--- a/src/fit.cpp
+++ b/src/fit.cpp
@@ -21,6 +21,7 @@
  */
 
 #include <cmath>
+#include <cfloat>
 #include <cstdint>
 #include <string>
 #include <vector>
@@ -245,10 +246,39 @@ FitGauss::FitGauss(std::vector<uint32_t> const &a_hist, double a_max_y,
   NLOPT_CALL(nlopt_set_min_objective, (opt, Gauss, &r));
   NLOPT_CALL(nlopt_set_ftol_rel, (opt, 1e-5));
   double x[4];
+  // Default initial parameter estimation.
   x[OFS] = 0.0;
   x[GAUSS_AMP] = a_max_y;
   x[GAUSS_MEAN] = 0.5 * (a_left + a_right);
   x[GAUSS_WIDTH] = 0.5 * (a_right - a_left);
+  // Estimate constant background as minimum bin value.
+  double v_min = DBL_MAX;
+  for (uint32_t i = r.left; i <= r.right; ++i) {
+    auto v_i = r.vec->at(i);
+    if (v_i < v_min) {
+      v_min = v_i;
+    }
+  }
+  x[OFS] = v_min;
+  // Base Gaussian parameter estimate on #counts, mean and RMS above
+  // constant background.
+  double sum = 0, sum_x = 0, sum_x2 = 0;
+  for (uint32_t i = r.left; i <= r.right; ++i) {
+    auto v_i = r.vec->at(i) - v_min;
+    sum    += v_i;
+    sum_x  += v_i * i;
+    sum_x2 += v_i * i * i;
+  }
+  // Only use estimate instead of default when it could be calculated.
+  if (sum >= 2) {
+    x[GAUSS_MEAN] = sum_x / sum;
+    double variance = (sum_x2 - sum_x * sum_x / sum) / (sum - 1);
+    // Variance 0 give fit problems...
+    if (variance > 0.) {
+      x[GAUSS_WIDTH] = 2.0 * variance;
+      x[GAUSS_AMP] = sum / sqrt(variance) / sqrt(2 * M_PI);
+    }
+  }
   double y;
 #if BENCHMARK
   double t0;


### PR DESCRIPTION
This allows it to fit a Gaussian directly in more cases.

- For comparison of behaviour without the default range-based parameter estimates, see the first figure. 
- The second figure shows success in most cases with 'spiky' spectra. 
- The third figure shows a different set of statistics, which were less successful.  But still more successful than the default.

Some disabled printf-based debug statements are in a second commit at https://github.com/inkdot7/plutt/tree/gauss_estimate_printf.  Did not include it since usually C++ finds printf() spicy...  

<img width="808" height="628" alt="Screenshot_fit3" src="https://github.com/user-attachments/assets/2344112f-b684-47a8-bf5c-29f09b3f5258" />

<img width="808" height="628" alt="Screenshot_fit2" src="https://github.com/user-attachments/assets/abf4a1ee-6b59-4fe0-ac11-250f5dff515c" />

<img width="808" height="628" alt="Screenshot_fit1" src="https://github.com/user-attachments/assets/02f1ac75-8537-410a-8d19-23b60f92ce82" />
