### PR TITLE
Compile fix (avoid warning about possily being used uninitialised).

### DIFF
--- a/src/unpacker.cpp
+++ b/src/unpacker.cpp
@@ -338,7 +338,7 @@ void Unpacker::BindSignal(Config *a_config, std::vector<char> const
   size_t arr_n; // Max size.
   std::string ctrl; // ctrl-variable, holds runtime array size.
   size_t len_ofs; // Offset in output buffer to runtime array size.
-  int max;
+  int max = 0;
   p += a_name.length();
   if (' ' == *p) {
     arr_n = 1;


### PR DESCRIPTION
Actually strange that it does not complain about `len_ofs` (else, else clause (line ~ 389) not immediately obviously that it is always set).